### PR TITLE
Tables without Primary Keys

### DIFF
--- a/src/groovy/grails/plugin/reveng/GrailsEntityPOJOClass.groovy
+++ b/src/groovy/grails/plugin/reveng/GrailsEntityPOJOClass.groovy
@@ -311,7 +311,7 @@ class GrailsEntityPOJOClass extends EntityPOJOClass {
 				}
 
 				clazz.table.uniqueKeyIterator.each { UniqueKey key ->
-					if (key.columnSpan == 1 || key.name == clazz.table.primaryKey.name) return
+					if (key.columnSpan == 1 || key.name == clazz.table.primaryKey?.name) return
 					if (key.columns[-1] == column) {
 						def otherNames = key.columns[0..-2].collect { "\"$it.name\"" }
 						values.unique = '[' + otherNames.reverse().join(', ') + ']'


### PR DESCRIPTION
Had a problem using this tool with tables that did not have primary keys.  I made a very slight modification to support reverse engineering with tables without primary keys.
