### PR TITLE
JBoss maven repo seems not to work while installing plugin on Grails 1.4.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -13,7 +13,7 @@ grails.project.dependency.resolution = {
 		grailsHome()
 		grailsCentral()
 
-		mavenRepo 'http://repository.jboss.com/maven2/'
+		mavenRepo 'https://repository.jboss.org/nexus/content/repositories/central/'
 	}
 
 	dependencies {


### PR DESCRIPTION
JBoss maven repo seems not to work while installing plugin on Grails 1.4.0.M1.
In the previous repo url, there are missing dependencies :
 * org.hibernate#hibernate-tools;3.2.4.GA
 * freemarker#freemarker;2.3.8
 * org.beanshell#bsh;2.0b4
 * org.hibernate#jtidy;r8-20060801
